### PR TITLE
Add counters to a set to track all counters

### DIFF
--- a/lib/split/counters.rb
+++ b/lib/split/counters.rb
@@ -21,6 +21,7 @@ module Split
     end
 
     def self.inc(name, experiment, alternative)
+      Split.redis.sadd(:counters, name)
       Split.redis.hincrby(Split::Counters.hash_name_for_name(name), Split::Counters.keyname_for_experiment_and_alternative(experiment, alternative), 1)
     end
 
@@ -33,6 +34,7 @@ module Split
     end
 
     def self.delete(name)
+      Split.redis.srem(:counters, name)
       Split.redis.del(Split::Counters.hash_name_for_name(name))
     end
 
@@ -52,7 +54,7 @@ module Split
     end
 
     def self.all_counter_names
-      Split.redis.keys("co:*").collect { |k| k.gsub(/^.*:/,"") }
+      Split.redis.smembers(:counters)
     end
   end
 end

--- a/spec/counters_spec.rb
+++ b/spec/counters_spec.rb
@@ -17,6 +17,7 @@ describe Split::Counters do
     it "should create a counter upon using it, if it does not exist" do
       Split::Counters.inc('co', 'exp1', 'alt1')
       Split::Counters.current_value('co', 'exp1', 'alt1').should eq("1")
+      Split::Counters.all_counter_names.should include('co')
     end
 
     it "should create a counter directly upon using it, if it does not exist" do
@@ -31,6 +32,7 @@ describe Split::Counters do
       Split::Counters.exists?('co').should eq(true)
       Split::Counters.delete('co')
       Split::Counters.exists?('co').should eq(false)
+      Split::Counters.all_counter_names.should_not include('co')
     end
 
     it "should be possible to reset a counter" do


### PR DESCRIPTION
Using `Split.redis.keys("co:*")` in production is dangerous; if the Redis datastore has a large amount of keys, this command can cause timeouts. Instead of searching across all keys for the counters, this will add them to a set when incremented, remove them when deleted, and simply check the set to find all of the counters.
