### PR TITLE
Fix Rails 6 autoloading deprecation warning "DEPRECATION WARNING: Ini…

### DIFF
--- a/lib/split/counters.rb
+++ b/lib/split/counters.rb
@@ -64,8 +64,10 @@ module Split::Helper
 end
 
 if defined?(Rails)
-  class ActionController::Base
-    ActionController::Base.send :include, Split::CounterHelper
-    ActionController::Base.helper Split::CounterHelper
+  ActiveSupport.on_load(:action_controller_base) do
+    class ActionController::Base
+      ActionController::Base.send :include, Split::CounterHelper
+      ActionController::Base.helper Split::CounterHelper
+    end
   end
 end


### PR DESCRIPTION
…tialization autoloaded the constants ActionText::ContentHelper and ActionText::TagHelper"

Hello 👋 
Issue is explained in this thread: https://github.com/rails/rails/issues/36546

In short: On boot, `split-counters` is calling `ActionController::Base` before it is defined, thus requiring to autoload the constant, which raises a deprecation in Rails 6 Zeitwerk mode.

This PR makes sure that we wait for `ActiveSupport` to load before monkey patching `ActionController::Base`.
`split` had the same issue, and they applied the same fix.

Thanks! A quick release would be very much appreciated ♥️